### PR TITLE
Test PR for built-in detector build on ppc64le

### DIFF
--- a/.tekton/odh-built-in-detector-pull-request.yaml
+++ b/.tekton/odh-built-in-detector-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux built-in-detector"
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
   labels:


### PR DESCRIPTION
Created this pull request to verify the Guardrails built-in detector's Konflux build on the Power architecture.