### PR TITLE
chore: upgrade `urllib3`

### DIFF
--- a/detectors/built_in/requirements.txt
+++ b/detectors/built_in/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==2.6.2
+urllib3==2.6.3
 markdown==3.8.2
 jsonschema==4.24.0
 xmlschema==4.1.0

--- a/detectors/common/requirements.txt
+++ b/detectors/common/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==2.6.2
+urllib3==2.6.3
 fastapi==0.121.2
 uvicorn==0.30.5
 httpx==0.27.0

--- a/detectors/huggingface/requirements.txt
+++ b/detectors/huggingface/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==2.6.2
+urllib3==2.6.3
 transformers==4.57.1
 sentencepiece==0.2.1
 tiktoken==0.12.0


### PR DESCRIPTION
Bump `urllib3` to version 2.6.3 to deal with [RHOAIENG-44968](https://redhat.atlassian.net/issues?jql=filter%20%3D%20%22All%20Open%20CVEs%22%0AAND%20project%20%3D%20RHOAIENG%0AAND%20component%20%3D%20%22AI%20Safety%22&selectedIssue=RHOAIENG-44968)