### PR TITLE
Fix Konflux builtIn Dockerfile to use pyproject.toml

### DIFF
--- a/detectors/Dockerfile.konflux.builtIn
+++ b/detectors/Dockerfile.konflux.builtIn
@@ -1,18 +1,9 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal as base
-RUN microdnf update -y && \
-    microdnf install -y --nodocs \
-        python-pip python-devel && \
-    pip install --upgrade --no-cache-dir pip wheel && \
-    microdnf clean all
+FROM registry.access.redhat.com/ubi9/python-312@sha256:4a6f6abc00071bc1a9c6c327830e0aef994e0f819411de2c0fd99ea2b2fd99ff as base
 
-# FROM icr.io/fm-stack/ubi9-minimal-py39-torch as builder
 FROM base as builder
 
-COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY ./built_in/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY ./pyproject.toml .
+RUN pip install --no-cache-dir ".[built-in]"
 
 FROM builder
 


### PR DESCRIPTION
## Summary

The upstream merge removed individual `requirements.txt` files in favor of `pyproject.toml`. This broke the Konflux builtIn Dockerfile build.

- Use `ubi9/python-312` base image (has Python 3.12 + pip pre-installed)
- Replace removed `requirements.txt` references with `pip install ".[built-in]"`
- Remove unnecessary microdnf step (not available in python-312 image)

## Test plan

- [x] Konflux builtIn build passes