### PR TITLE
Fix Dockerfile source copy for pyproject.toml package discovery

### DIFF
--- a/detectors/Dockerfile.konflux.builtIn
+++ b/detectors/Dockerfile.konflux.builtIn
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/python-312@sha256:4a6f6abc00071bc1a9c6c3278
 
 FROM base as builder
 
-COPY ./pyproject.toml .
+COPY . .
 RUN pip install --no-cache-dir ".[built-in]"
 
 FROM builder


### PR DESCRIPTION
Because of https://github.com/opendatahub-io/guardrails-detectors/pull/89, changes are required to Dockerfile.konflux