### PR TITLE
Fix Dockerfile source copy for pyproject.toml package discovery

### DIFF
--- a/detectors/Dockerfile.konflux.hf
+++ b/detectors/Dockerfile.konflux.hf
@@ -80,8 +80,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then                               \
         PREFIX=/usr/local make -C /openblas install                     ;\
     fi
 
-COPY ./pyproject.toml .
-RUN pip install --no-cache-dir .
+COPY . .
 
 RUN export CURDIR=$(pwd) && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \


### PR DESCRIPTION
Because of https://github.com/opendatahub-io/guardrails-detectors/pull/89, changes are required to Dockerfile.konflux