### PR TITLE
Enable hermetic builds for HF detector on rhoai-3.5

### DIFF
--- a/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
+++ b/.tekton/odh-guardrails-detector-huggingface-runtime-pull-request.yaml
@@ -37,8 +37,32 @@ spec:
     value: Dockerfile.konflux.hf
   - name: path-context
     value: detectors
+  - name: build-args-file
+    value: .konflux/base-images.conf
   - name: hermetic
-    value: false
+    value: true
+  - name: allow-cross-platform-images
+    value: "true"
+  - name: prefetch-input
+    value: |
+      [
+      {
+        "type": "pip",
+        "path": "detectors/requirements-hf/cuda",
+        "requirements_files": ["requirements.txt"],
+        "binary":{
+          "arch": "x86_64,aarch64"
+        }
+      },
+      {
+        "type": "pip",
+        "path": "detectors/requirements-hf/cpu",
+        "requirements_files": ["requirements.txt"],
+        "binary":{
+          "arch": "ppc64le,s390x"
+        }
+      }
+      ]
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-guardrails-detector-huggingface-runtime-v3-5-push.yaml
+++ b/.tekton/odh-guardrails-detector-huggingface-runtime-v3-5-push.yaml
@@ -38,8 +38,32 @@ spec:
     value: Dockerfile.konflux.hf
   - name: path-context
     value: detectors
+  - name: build-args-file
+    value: .konflux/base-images.conf
   - name: hermetic
-    value: false
+    value: true
+  - name: allow-cross-platform-images
+    value: "true"
+  - name: prefetch-input
+    value: |
+      [
+      {
+        "type": "pip",
+        "path": "detectors/requirements-hf/cuda",
+        "requirements_files": ["requirements.txt"],
+        "binary":{
+          "arch": "x86_64,aarch64"
+        }
+      },
+      {
+        "type": "pip",
+        "path": "detectors/requirements-hf/cpu",
+        "requirements_files": ["requirements.txt"],
+        "binary":{
+          "arch": "ppc64le,s390x"
+        }
+      }
+      ]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
All the non-tekton changes are already synced from main (#362) . This PR makes necessary tekton changes.


## Summary

- Enable hermetic builds for the HuggingFace detector on `rhoai-3.5`
- Set `hermetic: true` with AIPCC base images (`build-args-file`)
- Add `prefetch-input` for cpu/cuda requirements derived from `pyproject.toml`
- Add `allow-cross-platform-images` for multi-arch builds

Applies to both pull-request and push pipelines.


Made with [Cursor](https://cursor.com)