### PR TITLE
chore(deps):pin starlette==1.0.1, pin urlib==2.7.0, bump fastapi==0.141.1

### DIFF
--- a/detectors/Dockerfile.builtIn
+++ b/detectors/Dockerfile.builtIn
@@ -1,18 +1,18 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal as base
 RUN microdnf update -y && \
     microdnf install -y --nodocs \
-        python-pip python-devel && \
-    pip install --upgrade --no-cache-dir pip wheel && \
+        python3.11 python3.11-pip python3.11-devel && \
+    pip3.11 install --upgrade --no-cache-dir pip wheel && \
     microdnf clean all
 
 # FROM icr.io/fm-stack/ubi9-minimal-py39-torch as builder
 FROM base as builder
 
 COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ./built_in/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 FROM builder
 
@@ -27,6 +27,6 @@ EXPOSE 8080
 # for backwards compatibility with existing k8s deployment configs
 RUN mkdir /app/bin &&\
      echo '#!/bin/bash' > /app/bin/regex-detector &&\
-    echo "uvicorn app:app --workers 4 --host 0.0.0.0 --port 8080 --log-config /app/detectors/common/log_conf.yaml" >> /app/bin/regex-detector &&\
+    echo "python3.11 -m uvicorn app:app --workers 4 --host 0.0.0.0 --port 8080 --log-config /app/detectors/common/log_conf.yaml" >> /app/bin/regex-detector &&\
     chmod +x /app/bin/regex-detector
 CMD ["/app/bin/regex-detector"]

--- a/detectors/Dockerfile.hf
+++ b/detectors/Dockerfile.hf
@@ -4,24 +4,24 @@ ARG TARGETARCH
 
 RUN microdnf update -y                                            && \
     microdnf install -y --nodocs                                     \
-        python-pip python-devel                                   && \
-    pip install --upgrade --no-cache-dir pip wheel                && \
+        python3.11 python3.11-pip python3.11-devel                && \
+    pip3.11 install --upgrade --no-cache-dir pip wheel             && \
     if [ "$TARGETARCH" = "ppc64le" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 rust cargo wget unzip              && \
-        pip install --upgrade --no-cache-dir 'cmake<4'             ; \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'          ; \
     elif [ "$TARGETARCH" = "s390x" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 make wget unzip rust cargo            \
-            gcc-gfortran python3-devel openblas-devel pkgconfig   && \
-        pip install --upgrade --no-cache-dir 'cmake<4'               \
+            gcc-gfortran python3.11-devel openblas-devel pkgconfig && \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'            \
                                         setuptools wheel           ; \
     fi                                                            && \
     microdnf clean all
 
 
 RUN if [ "$TARGETARCH" != "ppc64le" ] && [ "$TARGETARCH" != "s390x" ]; then \
-        pip install --no-cache-dir torch                            ; \
+        pip3.11 install --no-cache-dir torch                        ; \
     fi
 
 # Buildinf torch for ppc64le
@@ -38,11 +38,11 @@ ENV PATH="$HOME/.cargo/bin:$PATH"
 RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then                \
     source /opt/rh/gcc-toolset-13/enable                                              && \
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
-    cd pytorch && pip install -r requirements.txt                                     && \
-    python setup.py develop                                                           && \
+    cd pytorch && pip3.11 install -r requirements.txt                                 && \
+    python3.11 setup.py develop                                                       && \
     rm -f dist/torch*+git*whl                                                         && \
     MAX_JOBS=${MAX_JOBS:-$(nproc)}                                                       \
-    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip wheel . --wheel-dir /tmp/torchwheels/ ;\
+    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip3.11 wheel . --wheel-dir /tmp/torchwheels/ ;\
 fi
 
 # Building openblas for ppc64le
@@ -71,7 +71,7 @@ ARG TARGETARCH
 # Install PyTorch for ppc64le
 RUN --mount=type=bind,from=torch-builder,source=/tmp/,target=/wheels/,ro \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        HOME=/root pip install /wheels/torchwheels/*.whl                ;\
+        HOME=/root pip3.11 install /wheels/torchwheels/*.whl            ;\
     fi
 
 # Install OpenBlas for ppc64le
@@ -81,13 +81,13 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then                               \
     fi
 
 COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ./huggingface/requirements.txt .
 RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
        source /opt/rh/gcc-toolset-13/enable                            ; \
     fi                                                                && \
-    pip install --no-cache-dir -r requirements.txt
+    pip3.11 install --no-cache-dir -r requirements.txt
 
 RUN rm -rf /openblas && rm -rf /wheels
 
@@ -101,6 +101,6 @@ COPY ./huggingface/app.py /app
 COPY ./huggingface/detector.py /app
 
 EXPOSE 8000
-CMD ["uvicorn", "app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/common/log_conf.yaml"]
+CMD ["python3.11", "-m", "uvicorn", "app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/common/log_conf.yaml"]
 
 # gunicorn main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000

--- a/detectors/Dockerfile.hf
+++ b/detectors/Dockerfile.hf
@@ -5,7 +5,8 @@ ARG TARGETARCH
 RUN microdnf update -y                                            && \
     microdnf install -y --nodocs                                     \
         python3.11 python3.11-pip python3.11-devel                && \
-    pip3.11 install --upgrade --no-cache-dir pip wheel             && \
+    rpm -e --nodeps python3.11-setuptools                          && \
+    pip3.11 install --upgrade --no-cache-dir pip setuptools wheel  && \
     if [ "$TARGETARCH" = "ppc64le" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 rust cargo wget unzip              && \
@@ -14,8 +15,7 @@ RUN microdnf update -y                                            && \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 make wget unzip rust cargo            \
             gcc-gfortran python3.11-devel openblas-devel pkgconfig && \
-        pip3.11 install --upgrade --no-cache-dir 'cmake<4'            \
-                                        setuptools wheel           ; \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'          ; \
     fi                                                            && \
     microdnf clean all
 
@@ -39,10 +39,11 @@ RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then       
     source /opt/rh/gcc-toolset-13/enable                                              && \
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
     cd pytorch && pip3.11 install -r requirements.txt                                 && \
-    python3.11 setup.py develop                                                       && \
-    rm -f dist/torch*+git*whl                                                         && \
+    mkdir -p /tmp/torchwheels                                                         && \
     MAX_JOBS=${MAX_JOBS:-$(nproc)}                                                       \
-    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip3.11 wheel . --wheel-dir /tmp/torchwheels/ ;\
+    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1                        \
+    python3.11 setup.py bdist_wheel                                                   && \
+    cp dist/*.whl /tmp/torchwheels/                                                    ;\
 fi
 
 # Building openblas for ppc64le

--- a/detectors/Dockerfile.judge
+++ b/detectors/Dockerfile.judge
@@ -1,17 +1,17 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal as base
 RUN microdnf update -y && \
     microdnf install -y --nodocs \
-        python-pip python-devel && \
-    pip install --upgrade --no-cache-dir pip wheel && \
+        python3.11 python3.11-pip python3.11-devel && \
+    pip3.11 install --upgrade --no-cache-dir pip wheel && \
     microdnf clean all
 
 FROM base as builder
 
 COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ./llm_judge/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 FROM builder
 
@@ -24,6 +24,6 @@ COPY ./llm_judge/detector.py /app/detectors/llm_judge/detector.py
 RUN touch /app/detectors/llm_judge/__init__.py
 
 EXPOSE 8000
-CMD ["uvicorn", "detectors.llm_judge.app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/app/detectors/common/log_conf.yaml"]
+CMD ["python3.11", "-m", "uvicorn", "detectors.llm_judge.app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/app/detectors/common/log_conf.yaml"]
 
 # gunicorn main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000

--- a/detectors/Dockerfile.konflux.builtIn
+++ b/detectors/Dockerfile.konflux.builtIn
@@ -1,18 +1,18 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal as base
 RUN microdnf update -y && \
     microdnf install -y --nodocs \
-        python-pip python-devel && \
-    pip install --upgrade --no-cache-dir pip wheel && \
+        python3.11 python3.11-pip python3.11-devel && \
+    pip3.11 install --upgrade --no-cache-dir pip wheel && \
     microdnf clean all
 
 # FROM icr.io/fm-stack/ubi9-minimal-py39-torch as builder
 FROM base as builder
 
 COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ./built_in/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 FROM builder
 
@@ -27,7 +27,7 @@ EXPOSE 8080
 # for backwards compatibility with existing k8s deployment configs
 RUN mkdir /app/bin &&\
      echo '#!/bin/bash' > /app/bin/regex-detector &&\
-    echo "uvicorn app:app --workers 4 --host 0.0.0.0 --port 8080 --log-config /app/detectors/common/log_conf.yaml" >> /app/bin/regex-detector &&\
+    echo "python3.11 -m uvicorn app:app --workers 4 --host 0.0.0.0 --port 8080 --log-config /app/detectors/common/log_conf.yaml" >> /app/bin/regex-detector &&\
     chmod +x /app/bin/regex-detector
 CMD ["/app/bin/regex-detector"]
 

--- a/detectors/Dockerfile.konflux.hf
+++ b/detectors/Dockerfile.konflux.hf
@@ -4,23 +4,23 @@ ARG TARGETARCH
 
 RUN microdnf update -y                                            && \
     microdnf install -y --nodocs                                     \
-        python-pip python-devel                                   && \
-    pip install --upgrade --no-cache-dir pip wheel                && \
+        python3.11 python3.11-pip python3.11-devel                && \
+    pip3.11 install --upgrade --no-cache-dir pip wheel             && \
     if [ "$TARGETARCH" = "ppc64le" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 rust cargo wget unzip              && \
-        pip install --upgrade --no-cache-dir 'cmake<4'             ; \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'          ; \
     elif [ "$TARGETARCH" = "s390x" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 make wget unzip rust cargo            \
-            gcc-gfortran python3-devel openblas-devel pkgconfig   && \
-        pip install --upgrade --no-cache-dir 'cmake<4'               \
+            gcc-gfortran python3.11-devel openblas-devel pkgconfig && \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'            \
                                         wheel           ; \
     fi                                                            && \
     microdnf clean all
 
 RUN if [ "$TARGETARCH" != "ppc64le" ] && [ "$TARGETARCH" != "s390x" ]; then \
-        pip install --no-cache-dir torch                            ; \
+        pip3.11 install --no-cache-dir torch                        ; \
     fi
 
 # Buildinf torch for ppc64le
@@ -37,11 +37,11 @@ ENV PATH="$HOME/.cargo/bin:$PATH"
 RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then                \
     source /opt/rh/gcc-toolset-13/enable                                              && \
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
-    cd pytorch && pip install -r requirements.txt                                     && \
-    python setup.py develop                                                           && \
+    cd pytorch && pip3.11 install -r requirements.txt                                 && \
+    python3.11 setup.py develop                                                       && \
     rm -f dist/torch*+git*whl                                                         && \
     MAX_JOBS=${MAX_JOBS:-$(nproc)}                                                       \
-    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip wheel . --wheel-dir /tmp/torchwheels/ ;\
+    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip3.11 wheel . --wheel-dir /tmp/torchwheels/ ;\
 fi
 
 # Building openblas for ppc64le
@@ -70,7 +70,7 @@ ARG TARGETARCH
 # Install PyTorch for ppc64le
 RUN --mount=type=bind,from=torch-builder,source=/tmp/,target=/wheels/,ro \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        HOME=/root pip install /wheels/torchwheels/*.whl                ;\
+        HOME=/root pip3.11 install /wheels/torchwheels/*.whl            ;\
     fi
 
 # Install OpenBlas for ppc64le
@@ -80,13 +80,13 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then                               \
     fi
 
 COPY ./common/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3.11 install --no-cache-dir -r requirements.txt
 
 COPY ./huggingface/requirements.txt .
 RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
        source /opt/rh/gcc-toolset-13/enable                            ; \
     fi                                                                && \
-    pip install --no-cache-dir -r requirements.txt
+    pip3.11 install --no-cache-dir -r requirements.txt
 
 RUN rm -rf /openblas && rm -rf /wheels
 
@@ -100,7 +100,7 @@ COPY ./huggingface/app.py /app
 COPY ./huggingface/detector.py /app
 
 EXPOSE 8000
-CMD ["uvicorn", "app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/common/log_conf.yaml"]
+CMD ["python3.11", "-m", "uvicorn", "app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000", "--log-config", "/common/log_conf.yaml"]
 
 # gunicorn main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
 

--- a/detectors/Dockerfile.konflux.hf
+++ b/detectors/Dockerfile.konflux.hf
@@ -5,7 +5,8 @@ ARG TARGETARCH
 RUN microdnf update -y                                            && \
     microdnf install -y --nodocs                                     \
         python3.11 python3.11-pip python3.11-devel                && \
-    pip3.11 install --upgrade --no-cache-dir pip wheel             && \
+    rpm -e --nodeps python3.11-setuptools                          && \
+    pip3.11 install --upgrade --no-cache-dir pip setuptools wheel  && \
     if [ "$TARGETARCH" = "ppc64le" ]; then                           \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 rust cargo wget unzip              && \
@@ -14,8 +15,7 @@ RUN microdnf update -y                                            && \
         microdnf install -y --nodocs                                 \
             git gcc-toolset-13 make wget unzip rust cargo            \
             gcc-gfortran python3.11-devel openblas-devel pkgconfig && \
-        pip3.11 install --upgrade --no-cache-dir 'cmake<4'            \
-                                        wheel           ; \
+        pip3.11 install --upgrade --no-cache-dir 'cmake<4'          ; \
     fi                                                            && \
     microdnf clean all
 
@@ -38,10 +38,11 @@ RUN if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then       
     source /opt/rh/gcc-toolset-13/enable                                              && \
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
     cd pytorch && pip3.11 install -r requirements.txt                                 && \
-    python3.11 setup.py develop                                                       && \
-    rm -f dist/torch*+git*whl                                                         && \
+    mkdir -p /tmp/torchwheels                                                         && \
     MAX_JOBS=${MAX_JOBS:-$(nproc)}                                                       \
-    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip3.11 wheel . --wheel-dir /tmp/torchwheels/ ;\
+    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1                        \
+    python3.11 setup.py bdist_wheel                                                   && \
+    cp dist/*.whl /tmp/torchwheels/                                                    ;\
 fi
 
 # Building openblas for ppc64le

--- a/detectors/common/requirements.txt
+++ b/detectors/common/requirements.txt
@@ -1,7 +1,8 @@
-fastapi==0.121.2
+fastapi==0.141.1
+starlette==1.0.1
 uvicorn==0.30.5
 httpx==0.27.0
-urllib3>=2.6.3
+urllib3==2.7.0
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 PyYAML==6.0.2

--- a/detectors/common/scheme.py
+++ b/detectors/common/scheme.py
@@ -119,7 +119,8 @@ class ContentAnalysisHttpRequest(BaseModel):
         ],
     )
     detector_params: Optional[Dict] = Field(
-        description="Optional detector parameters, used on a per-detector basis"
+        default=None,
+        description="Optional detector parameters, used on a per-detector basis",
     )
 
 
@@ -135,6 +136,22 @@ class ContentAnalysisResponse(BaseModel):
         default=None,
     )
     metadata: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Additional metadata from evaluation")
+    sequence_classification: Optional[str] = Field(
+        default=None,
+        description="Predicted sequence-level classification label, populated by sequence-classification or causal-LM based detectors",
+    )
+    sequence_probability: Optional[float] = Field(
+        default=None,
+        description="Probability/confidence associated with the sequence_classification label",
+    )
+    token_classifications: Optional[List[Any]] = Field(
+        default=None,
+        description="Optional per-token classification labels, populated by token-classification based detectors",
+    )
+    token_probabilities: Optional[List[float]] = Field(
+        default=None,
+        description="Optional per-token classification probabilities, populated by token-classification based detectors",
+    )
 
 
 class ContentsAnalysisResponse(RootModel):

--- a/detectors/huggingface/detector.py
+++ b/detectors/huggingface/detector.py
@@ -216,6 +216,8 @@ class Detector:
                     score=prob_of_risk,
                     text=text,
                     evidences=[],
+                    sequence_classification=risk_name,
+                    sequence_probability=prob_of_risk,
                 )
             )
         return content_analyses
@@ -254,10 +256,12 @@ class Detector:
                         ContentAnalysisResponse(
                             start=0,
                             end=len(text),
-                            detection_type=label,
-                            score=prob,
+                            detection_type="sequence_classification",
+                            score=float(prob),
                             text=text,
                             evidences=[],
+                            sequence_classification=label,
+                            sequence_probability=float(prob),
                             **({"detection": detection_value} if detection_value is not None else {})
                         )
                     )

--- a/tests/detectors/huggingface/test_method_initialize_model.py
+++ b/tests/detectors/huggingface/test_method_initialize_model.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 # local imports
-from detectors.huggingface.scheme import ContentAnalysisResponse
 from detectors.huggingface.detector import Detector
 
 

--- a/tests/detectors/huggingface/test_method_run.py
+++ b/tests/detectors/huggingface/test_method_run.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 # relative imports
 from detectors.huggingface.detector import Detector, ContentAnalysisResponse
-from scheme import ContentAnalysisHttpRequest
+from detectors.common.scheme import ContentAnalysisHttpRequest
 
 
 @pytest.fixture


### PR DESCRIPTION
* Explicitly pin starlette==1.0.1, pin urlib==2.7.0, and bump fastapi==0.141.1
* Pin Python==3.11 in Dockerfiles to satisfy urlib Python version requirement
* Fix broken tests by populating `ContentAnalysisResponse` in `detectors/common/scheme.py` with required fields