### PR TITLE
fix: use pull_request_target in gatekeeper workflow

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,7 +1,7 @@
 name: Post-Codefreeze Gatekeeper
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
       - 'rhoai-3.5'


### PR DESCRIPTION
Updates the gatekeeper workflow to use `pull_request_target` instead of `pull_request` and points to `@main`.

Jira: [RHOAIENG-82825](https://redhat.atlassian.net/browse/RHOAIENG-82825)