### PR TITLE
RHOAI 3.5 Built-in Detectors Vulnerability fixes- regex detectors, sandboxing, xmlschemas - #88

### DIFF
--- a/detectors/built_in/custom_detectors_wrapper.py
+++ b/detectors/built_in/custom_detectors_wrapper.py
@@ -110,7 +110,7 @@ def custom_func_wrapper(func: Callable, func_name: str, s: str, headers: dict, f
 
 def static_code_analysis(module_path, forbidden_imports=None, forbidden_calls=None):
     """
-    Perform static code analysis on a Python module to check for forbidden imports and function calls.
+    Best-effort static check for common unsafe imports and calls. Not a security sandbox.
     Returns a list of issues found.
     """
     if forbidden_imports is None:

--- a/detectors/built_in/file_type_detectors.py
+++ b/detectors/built_in/file_type_detectors.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 
@@ -141,8 +142,7 @@ def is_valid_xml_schema(s: str, schema) -> Optional[ContentAnalysisResponse]:
     if is_valid is not None:
         return is_valid
     try:
-        # schema is expected to be a string containing the XSD
-        xs = xmlschema.XMLSchema(schema)
+        xs = xmlschema.XMLSchema(io.StringIO(schema), allow='none', defuse='always')
     except Exception:
         return ContentAnalysisResponse(
             start=0,

--- a/detectors/built_in/regex_detectors.py
+++ b/detectors/built_in/regex_detectors.py
@@ -1,4 +1,5 @@
-import re
+import os
+import regex
 from time import time
 from http.client import HTTPException
 from typing import List
@@ -7,6 +8,8 @@ from base_detector_registry import BaseDetectorRegistry
 from detectors.common.scheme import ContentAnalysisResponse
 
 logger = logging.getLogger(__name__)
+
+REGEX_TIMEOUT = float(os.environ.get("REGEX_TIMEOUT", "1.0"))
 
 def email_address_detector(string: str) -> List[ContentAnalysisResponse]:
     """Detect email addresses in the text contents"""
@@ -34,7 +37,7 @@ def credit_card_detector(string: str) -> List[ContentAnalysisResponse]:
     )
     # Find all matches and filter with Luhn check
     detections = []
-    for match in re.finditer(pattern, string):
+    for match in regex.finditer(pattern, string, timeout=REGEX_TIMEOUT):
         cc_number = match.group(0).replace(" ", "").replace("-", "")
         if is_luhn_valid(cc_number):
             detections.append(
@@ -68,17 +71,17 @@ def is_luhn_valid(card_number):
 
 def ipv4_detector(string: str) -> List[ContentAnalysisResponse]:
     """Detect IPv4 addresses in the text contents"""
-    pattern = re.compile(
+    pattern = regex.compile(
         u"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
-        re.IGNORECASE,
+        regex.IGNORECASE,
     )
     return get_regex_detections(string, pattern, "pii", "ipv4")
 
 def ipv6_detector(string: str) -> List[ContentAnalysisResponse]:
     """Detect IPv6 addresses in the text contents"""
-    pattern = re.compile(
+    pattern = regex.compile(
         u"\s*(?!.*::.*::)(?:(?!:)|:(?=:))(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)){6}(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)[0-9a-f]{0,4}(?:(?<=::)|(?<!:)|(?<=:)(?<!::):)|(?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)){3})\s*",
-        re.VERBOSE | re.IGNORECASE | re.DOTALL,
+        regex.VERBOSE | regex.IGNORECASE | regex.DOTALL,
     )
     return get_regex_detections(string, pattern, "pii", "ipv6")
 
@@ -102,7 +105,7 @@ def uk_post_code_detector(string: str) -> List[ContentAnalysisResponse]:
 
 def get_regex_detections(string, pattern, detection_type, detection) -> List[ContentAnalysisResponse]:
     detections = []
-    for match in re.finditer(pattern, string):
+    for match in regex.finditer(pattern, string, timeout=REGEX_TIMEOUT):
         detections.append(
             ContentAnalysisResponse(
                 start=match.start(),

--- a/detectors/pyproject.toml
+++ b/detectors/pyproject.toml
@@ -27,6 +27,7 @@ built-in = [
     "jsonschema==4.24.0",
     "xmlschema==4.1.0",
     "requests==2.32.5",
+    "regex>=2024.0.0",
 ]
 all = [
     "guardrails-detectors[huggingface,built-in]",

--- a/docs/custom_detectors.md
+++ b/docs/custom_detectors.md
@@ -13,8 +13,12 @@ The following rules apply:
       * see the `over_100_characters` example in [custom_detectors.py](detectors/built_in/custom_detectors/custom_detectors.py) for usage
    3) Dict response that are parseable as a `ContentAnalysisResponse` object are considered a detection
       * see the `contains_word` example in [custom_detectors.py](detectors/built_in/custom_detectors/custom_detectors.py) for usage
-4) This code may not import `os`, `subprocess`, `sys`, or `shutil` for security reasons
-5) This code may not call `eval`, `exec`, `open`, `compile`, or `input` for security reasons
+4) This code may not import `os`, `subprocess`, `sys`, or `shutil`
+5) This code may not call `eval`, `exec`, `open`, `compile`, or `input`
+
+> **Security note:** Rules 4 and 5 are enforced by a static analysis check that catches common
+> unsafe patterns, but they are not a security sandbox. Custom detector code runs with full pod
+> privileges. Only mount `custom_detectors.py` from sources you trust.
 
 
 ## Utility Decorators


### PR DESCRIPTION
- Sanitize and defuse user-supplied XML schemas
- Clarify sandboxing limitations of custom_detectors code
- Migrate to regex package to avoid potential timeout issues with re

## Addresses
- https://redhat.atlassian.net/browse/RHOAIENG-83459
- https://redhat.atlassian.net/browse/RHOAIENG-83461